### PR TITLE
Rename 'DisplaySpend' to 'DisplayCampaignSpend' because of recent SW change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [Changelog](https://github.com/yola/sitewit/releases)
 
+## DEV
+
+* Rename 'DisplaySpend' to 'DisplayCampaignSpend' in 
+  `SPEND_CHARGE_ITEM_TYPES` constant
+
 ## 0.10.0
 
 * Add optional `billing_type` and `expiry_date` parameters to 

--- a/sitewit/constants.py
+++ b/sitewit/constants.py
@@ -15,4 +15,4 @@ class CampaignTypes(object):
 CAMPAIGN_SERVICES = {
     CampaignServiceTypes.QUICKSTART: 'QuickStart Campaign'
 }
-SPEND_CHARGE_ITEM_TYPES = ('DisplaySpend', 'SearchCampaignSpend')
+SPEND_CHARGE_ITEM_TYPES = ('DisplayCampaignSpend', 'SearchCampaignSpend')

--- a/tests/campaigns/test_integration.py
+++ b/tests/campaigns/test_integration.py
@@ -3,7 +3,8 @@ from uuid import uuid4
 
 from dateutil.parser import parse
 
-from sitewit.constants import BillingTypes, CampaignServiceTypes, CampaignTypes
+from sitewit.constants import (
+    BillingTypes, CampaignServiceTypes, CampaignTypes, SPEND_CHARGE_ITEM_TYPES)
 from sitewit.models import Subscription
 from tests.base import SitewitTestCase
 
@@ -481,6 +482,10 @@ class TestRefillSearchCampaignSubscription(BaseCampaignTestCase):
 
     def test_refills_subscription_for_given_amount(self):
         self.assertEqual(self.price, self.expected_price)
+
+    def test_response_contains_spend_charge_item(self):
+        item_types = set(i['type'] for i in self.response['charge']['items'])
+        self.assertTrue(item_types & set(SPEND_CHARGE_ITEM_TYPES))
 
 
 class TestRefillDisplayCampaignSubscription(


### PR DESCRIPTION
Related discussion: https://github.com/yola/p-whitelabel/issues/1095#issuecomment-350732335